### PR TITLE
feat: [EC-2390] Remove sensitive data from DB

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -275,9 +275,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		if ( 'yes' === $this->enabled ) {
 
 			// Not available if the keys aren't set.
-			if ( ! $this->are_keys_set() ) {
+/*			if ( ! $this->are_keys_set() ) {
 				return false;
-			}
+			}*/
 
 			// Not available if using live mode without SSL.
 			if ( $this->needs_ssl_setup() ) {

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -41,13 +41,7 @@ class WC_Stripe_API {
 	 */
 	public static function get_secret_key() {
 		if ( ! self::$secret_key ) {
-			$options         = get_option( 'woocommerce_stripe_settings' );
-			$secret_key      = $options['secret_key'] ?? '';
-			$test_secret_key = $options['test_secret_key'] ?? '';
-
-			if ( isset( $options['testmode'] ) ) {
-				self::set_secret_key( 'yes' === $options['testmode'] ? $test_secret_key : $secret_key );
-			}
+				self::set_secret_key( PLATFORM_SECRET_KEY );
 		}
 		return self::$secret_key;
 	}
@@ -87,13 +81,20 @@ class WC_Stripe_API {
 		$app_info   = $user_agent['application'];
         $stripeSettings      = get_option(self::SG_ECOM_SETTING_STRIPE_NAME);
         $account_id = $stripeSettings['account_id']?? null;
+
+        $headers = [
+            'Authorization'  => 'Basic ' . base64_encode( self::get_secret_key() . ':' ),
+            'Stripe-Version' => self::STRIPE_API_VERSION,
+
+        ];
+
+        if ($account_id) {
+            $headers['Stripe-Account'] =  $account_id;
+        }
+
         $headers = apply_filters(
 			'woocommerce_stripe_request_headers',
-			[
-				'Authorization'  => 'Basic ' . base64_encode( self::get_secret_key() . ':' ),
-				'Stripe-Version' => self::STRIPE_API_VERSION,
-                'Stripe-Account' => $account_id
-			]
+			$headers
 		);
 
 		// These headers should not be overridden for this gateway.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
